### PR TITLE
Fix bug: added nmi3 to the list of indices computed when types=all is…

### DIFF
--- a/R/mclustcomp.R
+++ b/R/mclustcomp.R
@@ -182,7 +182,7 @@ mclustcomp <- function(x,y,types="all",tversky.param=list()){
   ##  {"all" or single name}
   ## Case 2  : a vector of names; c("f","rand")
   type_allnames = c("adjrand","chisq","f","fmi","jaccard","mhm","mirkin","mmm",
-                    "mi","nmi1","nmi2","overlap","pd","rand","sdc","smc","tanimoto",
+                    "mi","nmi1","nmi2","nmi3","overlap","pd","rand","sdc","smc","tanimoto",
                     "tversky","vdm","vi","wallace1","wallace2","jent","nvi")
   type_out   = unique(types)
   if ("all" %in% type_out){


### PR DESCRIPTION
Hi! Thank you for this great package, it is very useful.
I was trying it with the argument types=all and I found out that one of the indices (nmi3) that should be computed was not included
in the output dataframe. I fixed this minor bug by simply adding the corresponding string in the vector type_allnames.
Hope it helps :)